### PR TITLE
feat: Add setup.py to allow editable installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='era_5g_client',
+      version='0.0.1',
+      description='A client for 5G-ERA NetworkApps',
+      packages=['era_5g_client']
+     )


### PR DESCRIPTION
Add setup.py to allow editable installation of the repo with pip3 install -e .

Without this file, command 
pip3 install -e . 
results in: 
ERROR: File "setup.py" not found. Directory cannot be installed in editable mode